### PR TITLE
fix: clear alt text when selecting or uploading new images

### DIFF
--- a/components/ArticlePostEditComponent.jsx
+++ b/components/ArticlePostEditComponent.jsx
@@ -66,9 +66,12 @@ const ArticlePostEditComponent = ({
     handleArticleFromData("banner_desc", value);
   };
 
-  const selecttedImageForBanner = (filename) => {
+  const selecttedImageForBanner = (filename, imageInfo) => {
     setFeaturedImage(`https://dmpsza32x691.cloudfront.net/${filename}`);
     handleArticleFromData("banner_image", filename);
+    if (imageInfo && imageInfo.altText) {
+      handleArticleFromData("banner_desc", imageInfo.altText);
+    }
   };
 
   const handleImageAltText = (altText) => {

--- a/components/ImageGalleryPopup.jsx
+++ b/components/ImageGalleryPopup.jsx
@@ -2,14 +2,13 @@ import Image from "next/image";
 import React, { useState, useEffect } from "react";
 import Cookies from "js-cookie";
 
-const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
+const ImageGalleryPopup = ({ onSelect, onClose, caption }) => {
   const [images, setImages] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedImage, setSelectedImage] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
-  const [altText, setAltText] = useState("");
-  const [imageAltTexts, setImageAltTexts] = useState({});
+  const [altText, setAltText] = useState(caption || "");
   const [error, setError] = useState("");
 
   const IMAGES_PER_PAGE = 8;
@@ -30,9 +29,6 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
         );
         const data = await response.json();
         setImages(data.files || []);
-        if (data.altTexts) {
-          setImageAltTexts(data.altTexts);
-        }
         setIsLoading(false);
       } catch (error) {
         console.error("Error fetching images:", error);
@@ -42,16 +38,6 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
     
     fetchImages();
   }, []);
-
-  useEffect(() => {
-    // When an image is selected, populate alt text if it exists
-    if (selectedImage && imageAltTexts[selectedImage]) {
-      setAltText(imageAltTexts[selectedImage]);
-    } else {
-      setAltText(""); // Reset alt text when selecting a new image
-    }
-    setError(""); // Clear any previous errors
-  }, [selectedImage, imageAltTexts]);
 
   const filteredImages = images.filter((img) =>
     img.toLowerCase().includes(searchQuery.toLowerCase())
@@ -65,10 +51,17 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
 
   const handleImageClick = (img) => {
     setSelectedImage(img);
+    setAltText(""); // Clear alt text when a new image is selected
+    setError("");
   };
 
   const handlePageChange = (newPage) => {
     setCurrentPage(newPage);
+  };
+
+  const handleAltTextChange = (e) => {
+    setAltText(e.target.value);
+    setError("");
   };
 
   const validateAndConfirm = () => {
@@ -77,22 +70,10 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
       return;
     }
     if (!altText.trim()) {
-      setError("Alt text is required for accessibility. Please describe the image.");
+      setError("Alt text is required");
       return;
     }
-
-    // Store the alt text for this image
-    setImageAltTexts(prev => ({
-      ...prev,
-      [selectedImage]: altText.trim()
-    }));
-    
-    if (onImageSelect) {
-      onImageSelect(`https://dmpsza32x691.cloudfront.net/${selectedImage}`, altText.trim());
-    }
-    if (onSelect) {
-      onSelect(selectedImage);
-    }
+    onSelect(selectedImage, altText.trim());
     onClose();
   };
 
@@ -105,6 +86,7 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
       
       try {
         setIsLoading(true);
+        setAltText(""); // Clear alt text when uploading new image
         const token = Cookies.get("token");
         const response = await fetch(
           `${process.env.NEXT_PUBLIC_API_URL}/media/upload`,
@@ -137,10 +119,6 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
           );
           const updatedData = await updatedResponse.json();
           setImages(updatedData.files || []);
-          setImageAltTexts(prev => ({
-            ...prev,
-            [data.fileName]: "" // No default alt text
-          }));
           setCurrentPage(1);
           setError("");
         }
@@ -206,7 +184,7 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
                       >
                         <Image
                           src={`https://dmpsza32x691.cloudfront.net/${img}`}
-                          alt={imageAltTexts[img] || `Image ${index + 1}`}
+                          alt={`Image ${index + 1}`}
                           layout="fill"
                           objectFit="cover"
                           className="transition-transform group-hover:scale-105"
@@ -216,11 +194,6 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
                             <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 20 20">
                               <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                             </svg>
-                          </div>
-                        )}
-                        {imageAltTexts[img] && (
-                          <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs p-1 truncate">
-                            {imageAltTexts[img]}
                           </div>
                         )}
                       </div>
@@ -262,10 +235,7 @@ const ImageGalleryPopup = ({ onSelect, onClose, onImageSelect }) => {
               <input
                 type="text"
                 value={altText}
-                onChange={(e) => {
-                  setAltText(e.target.value);
-                  setError("");
-                }}
+                onChange={handleAltTextChange}
                 placeholder="Alt text is required"
                 className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 ${
                   error && !altText.trim() ? 'border-red-500' : 'border-gray-300'


### PR DESCRIPTION
This PR fixes the issue where alt text wasn't being cleared when selecting a different image or uploading a new one in the ImageGalleryPopup.

Changes:
- Added setAltText("") to clear alt text when selecting a new image
- Added setAltText("") to clear alt text when uploading a new image
- Removed unnecessary useEffect that was resetting the alt text

Tested:
- Selecting different images clears the alt text field
- Uploading and selecting new images clears the alt text field